### PR TITLE
feat: support non-PR event triggers via pr-number input

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ jobs:
 | `show-diff`            | ❌       | `false`                      | include the diff view in the comment?                                              |
 | `remove-stale-reports` | ❌       | `true`                       | remove report comments for old commits?                                            |
 | `show-no-changes`      | ❌       | `true`                       | post a comment even when there are no changes in the terraform plan?               |
+| `pr-number`            | ❌       | `-`                          | PR number to post the comment on (required when not triggered by a pull request event) |
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     default: "true"
     required: false
 
+  pr-number:
+    description: PR number to post the comment on (required when not triggered by a pull request event)
+    required: false
+
 runs:
   using: node24
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -31965,7 +31965,8 @@ function context () {
     customHeader: getMultilineInput('custom-header'),
     customFooter: getMultilineInput('custom-footer'),
     showHeader: getBooleanInput('show-header'),
-    showFooter: getBooleanInput('show-footer')
+    showFooter: getBooleanInput('show-footer'),
+    prNumber: getInput('pr-number')
   };
 
   // extract relevant variables
@@ -31981,19 +31982,21 @@ function context () {
     error$i('Missing required inputs');
     process.exit(1);
   }
-
-  // exit early
-  /* c8 ignore next 4 */
-  if (!pull_request) {
-    warning('not a pull request. exiting.');
-    process.exit(0);
-  }
-
-  // exit early
-  /* c8 ignore next 4 */
-  if (pull_request.state !== 'open') {
-    warning('action triggered on a closed pull request');
-    process.exit(0);
+  if (pull_request) {
+    // exit early
+    /* c8 ignore next 4 */
+    if (pull_request.state !== 'open') {
+      warning('action triggered on a closed pull request');
+      process.exit(0);
+    }
+    inputs.prNumber = inputs.prNumber ? parseInt(inputs.prNumber, 10) : pull_request.number;
+  } else if (inputs.prNumber) {
+    inputs.prNumber = parseInt(inputs.prNumber, 10);
+  } else {
+    // exit early
+    /* c8 ignore next 4 */
+    error$i('not a pull request and no pr-number input provided');
+    process.exit(1);
   }
   return inputs;
 }
@@ -42839,7 +42842,7 @@ class Alias extends Node.NodeBase {
             data = anchors.get(source);
         }
         /* istanbul ignore if */
-        if (!data || data.res === undefined) {
+        if (data?.res === undefined) {
             const msg = 'This should not happen: Alias anchor was not resolved?';
             throw new ReferenceError(msg);
         }
@@ -43706,6 +43709,7 @@ function createStringifyContext(doc, options) {
         nullStr: 'null',
         simpleKeys: false,
         singleQuote: null,
+        trailingComma: false,
         trueStr: 'true',
         verifyAliasOrder: true
     }, doc.schema.toStringOptions, options);
@@ -43917,7 +43921,7 @@ function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
             ws += `\n${stringifyComment_1.indentComment(cs, ctx.indent)}`;
         }
         if (valueStr === '' && !ctx.inFlow) {
-            if (ws === '\n')
+            if (ws === '\n' && valueComment)
                 ws = '\n\n';
         }
         else {
@@ -44260,12 +44264,22 @@ function stringifyFlowCollection({ items }, ctx, { flowChars, itemIndent }) {
         if (comment)
             reqNewline = true;
         let str = stringify_1$2.stringify(item, itemCtx, () => (comment = null));
-        if (i < items.length - 1)
+        reqNewline || (reqNewline = lines.length > linesAtValue || str.includes('\n'));
+        if (i < items.length - 1) {
             str += ',';
+        }
+        else if (ctx.options.trailingComma) {
+            if (ctx.options.lineWidth > 0) {
+                reqNewline || (reqNewline = lines.reduce((sum, line) => sum + line.length + 2, 2) +
+                    (str.length + 2) >
+                    ctx.options.lineWidth);
+            }
+            if (reqNewline) {
+                str += ',';
+            }
+        }
         if (comment)
             str += stringifyComment_1.lineComment(str, itemIndent, commentString(comment));
-        if (!reqNewline && (lines.length > linesAtValue || str.includes('\n')))
-            reqNewline = true;
         lines.push(str);
         linesAtValue = lines.length;
     }
@@ -44660,7 +44674,7 @@ function stringifyNumber({ format, minFractionDigits, tag, value }) {
     const num = typeof value === 'number' ? value : Number(value);
     if (!isFinite(num))
         return isNaN(num) ? '.nan' : num < 0 ? '-.inf' : '.inf';
-    let n = JSON.stringify(value);
+    let n = Object.is(value, -0) ? '-0' : JSON.stringify(value);
     if (!format &&
         minFractionDigits &&
         (!tag || tag === 'tag:yaml.org,2002:float') &&
@@ -46067,7 +46081,7 @@ const prettifyError = (src, lc) => (error) => {
     if (/[^ ]/.test(lineStr)) {
         let count = 1;
         const end = error.linePos[1];
-        if (end && end.line === line && end.col > col) {
+        if (end?.line === line && end.col > col) {
             count = Math.max(1, Math.min(end.col - col, 80 - ci));
         }
         const pointer = ' '.repeat(ci) + '^'.repeat(count);
@@ -46444,7 +46458,7 @@ function resolveBlockSeq({ composeNode, composeEmptyNode }, ctx, bs, onError, ta
         });
         if (!props.found) {
             if (props.anchor || props.tag || value) {
-                if (value && value.type === 'block-seq')
+                if (value?.type === 'block-seq')
                     onError(props.end, 'BAD_INDENT', 'All sequence items must start at the same column');
                 else
                     onError(offset, 'MISSING_CHAR', 'Sequence item without - indicator');
@@ -46642,7 +46656,7 @@ function resolveFlowCollection({ composeNode, composeEmptyNode }, ctx, fc, onErr
                 }
             }
             else if (value) {
-                if ('source' in value && value.source && value.source[0] === ':')
+                if ('source' in value && value.source?.[0] === ':')
                     onError(value, 'MISSING_CHAR', `Missing space after : in ${fcName}`);
                 else
                     onError(valueProps.start, 'MISSING_CHAR', `Missing , or : between ${fcName} items`);
@@ -46686,7 +46700,7 @@ function resolveFlowCollection({ composeNode, composeEmptyNode }, ctx, fc, onErr
     const expectedEnd = isMap ? '}' : ']';
     const [ce, ...ee] = fc.end;
     let cePos = offset;
-    if (ce && ce.source === expectedEnd)
+    if (ce?.source === expectedEnd)
         cePos = ce.offset + ce.source.length;
     else {
         const name = fcName[0].toUpperCase() + fcName.substring(1);
@@ -46772,7 +46786,7 @@ function composeCollection(CN, ctx, token, props, onError) {
     let tag = ctx.schema.tags.find(t => t.tag === tagName && t.collection === expType);
     if (!tag) {
         const kt = ctx.schema.knownTags[tagName];
-        if (kt && kt.collection === expType) {
+        if (kt?.collection === expType) {
             ctx.schema.tags.push(Object.assign({}, kt, { default: false }));
             tag = kt;
         }
@@ -47370,19 +47384,26 @@ function composeNode(ctx, token, props, onError) {
         case 'block-map':
         case 'block-seq':
         case 'flow-collection':
-            node = composeCollection_1.composeCollection(CN, ctx, token, props, onError);
-            if (anchor)
-                node.anchor = anchor.source.substring(1);
+            try {
+                node = composeCollection_1.composeCollection(CN, ctx, token, props, onError);
+                if (anchor)
+                    node.anchor = anchor.source.substring(1);
+            }
+            catch (error) {
+                // Almost certainly here due to a stack overflow
+                const message = error instanceof Error ? error.message : String(error);
+                onError(token, 'RESOURCE_EXHAUSTION', message);
+            }
             break;
         default: {
             const message = token.type === 'error'
                 ? token.message
                 : `Unsupported token (type: ${token.type})`;
             onError(token, 'UNEXPECTED_TOKEN', message);
-            node = composeEmptyNode(ctx, token.offset, undefined, null, props, onError);
             isSrcToken = false;
         }
     }
+    node ?? (node = composeEmptyNode(ctx, token.offset, undefined, null, props, onError));
     if (anchor && node.anchor === '')
         onError(anchor, 'BAD_ALIAS', 'Anchor cannot be an empty string');
     if (atKey &&
@@ -49209,7 +49230,7 @@ class Parser$1 {
     }
     *step() {
         const top = this.peek(1);
-        if (this.type === 'doc-end' && (!top || top.type !== 'doc-end')) {
+        if (this.type === 'doc-end' && top?.type !== 'doc-end') {
             while (this.stack.length > 0)
                 yield* this.pop();
             this.stack.push({
@@ -49741,7 +49762,7 @@ class Parser$1 {
             do {
                 yield* this.pop();
                 top = this.peek(1);
-            } while (top && top.type === 'flow-collection');
+            } while (top?.type === 'flow-collection');
         }
         else if (fc.end.length === 0) {
             switch (this.type) {
@@ -50254,14 +50275,15 @@ function report (data) {
 
 async function post ({
   token,
-  body
+  body,
+  prNumber
 }) {
   const octokit = getOctokit(token);
 
   // update PR
   await octokit.rest.issues.createComment({
     ...context$1.repo,
-    issue_number: context$1.payload.pull_request.number,
+    issue_number: prNumber,
     body
   });
 }
@@ -50270,18 +50292,12 @@ async function post ({
 async function stale (data) {
   const octokit = getOctokit(data.token);
   const {
-    repo,
-    payload: {
-      pull_request: {
-        number: issue_number
-      }
-    }
+    repo
   } = context$1;
+  const issue_number = data.prNumber;
 
-  // get issue comments
-  const {
-    data: results
-  } = await octokit.rest.issues.listComments({
+  // get all issue comments across pages
+  const results = await octokit.paginate(octokit.rest.issues.listComments, {
     ...repo,
     issue_number
   });
@@ -50301,7 +50317,7 @@ async function stale (data) {
         comment_id
       });
     } catch (error) {
-      warning(`Could not delete comment: ${comment_id}`);
+      warning(`Could not delete comment: ${comment_id}: ${error.message}`);
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ jobs:
 | `show-diff`            | ❌       | `false`                      | include the diff view in the comment?                                              |
 | `remove-stale-reports` | ❌       | `true`                       | remove report comments for old commits?                                            |
 | `show-no-changes`      | ❌       | `true`                       | post a comment even when there are no changes in the terraform plan?               |
+| `pr-number`            | ❌       | `-`                          | PR number to post the comment on (required when not triggered by a pull request event) |
 
 ## Examples
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -16,7 +16,8 @@ export default function () {
     customHeader: core.getMultilineInput('custom-header'),
     customFooter: core.getMultilineInput('custom-footer'),
     showHeader: core.getBooleanInput('show-header'),
-    showFooter: core.getBooleanInput('show-footer')
+    showFooter: core.getBooleanInput('show-footer'),
+    prNumber: core.getInput('pr-number')
   }
 
   // extract relevant variables
@@ -29,18 +30,21 @@ export default function () {
     process.exit(1)
   }
 
-  // exit early
-  /* c8 ignore next 4 */
-  if (!pull_request) {
-    core.warning('not a pull request. exiting.')
-    process.exit(0)
-  }
-
-  // exit early
-  /* c8 ignore next 4 */
-  if (pull_request.state !== 'open') {
-    core.warning('action triggered on a closed pull request')
-    process.exit(0)
+  if (pull_request) {
+    // exit early
+    /* c8 ignore next 4 */
+    if (pull_request.state !== 'open') {
+      core.warning('action triggered on a closed pull request')
+      process.exit(0)
+    }
+    inputs.prNumber = inputs.prNumber ? parseInt(inputs.prNumber, 10) : pull_request.number
+  } else if (inputs.prNumber) {
+    inputs.prNumber = parseInt(inputs.prNumber, 10)
+  } else {
+    // exit early
+    /* c8 ignore next 4 */
+    core.error('not a pull request and no pr-number input provided')
+    process.exit(1)
   }
 
   return inputs

--- a/lib/post.js
+++ b/lib/post.js
@@ -1,12 +1,12 @@
 import { getOctokit, context }  from '@actions/github'
 
-export default async function ({ token, body }) {
+export default async function ({ token, body, prNumber }) {
   const octokit = getOctokit(token)
 
   // update PR
   await octokit.rest.issues.createComment({
     ...context.repo,
-    issue_number: context.payload.pull_request.number,
+    issue_number: prNumber,
     body
   })
 }

--- a/lib/stale.js
+++ b/lib/stale.js
@@ -5,10 +5,11 @@ import { getOctokit, context } from '@actions/github'
 export default async function (data) {
   const octokit = getOctokit(data.token)
 
-  const { repo, payload: { pull_request: { number: issue_number } } } = context
+  const { repo } = context
+  const issue_number = data.prNumber
 
-  // get issue comments
-  const { data: results } = await octokit.rest.issues.listComments({ ...repo, issue_number })
+  // get all issue comments across pages
+  const results = await octokit.paginate(octokit.rest.issues.listComments, { ...repo, issue_number })
 
   // get action comments
   // filter out comments that include the unique identifier but not the run signature to get stale comments from previous runs
@@ -19,7 +20,7 @@ export default async function (data) {
     try {
       await octokit.rest.issues.deleteComment({ ...repo, issue_number, comment_id })
     } catch (error) {
-      warning(`Could not delete comment: ${comment_id}`)
+      warning(`Could not delete comment: ${comment_id}: ${error.message}`)
     }
   }
 }

--- a/test/context-pr-number.js
+++ b/test/context-pr-number.js
@@ -1,0 +1,29 @@
+import { URL, fileURLToPath } from 'url'
+import { join } from 'path'
+
+import { test } from 'tap'
+
+const root = fileURLToPath(new URL('./', import.meta.url))
+
+test('context with pr-number input and no pull request event', async assert => {
+  process.env['INPUT_SHOW-DIFF'] = 'false'
+  process.env['INPUT_SHOW-PLAN'] = 'true'
+  process.env['INPUT_SHOW-HEADER'] = 'true'
+  process.env['INPUT_SHOW-FOOTER'] = 'true'
+  process.env['INPUT_SHOW-NO-CHANGES'] = 'true'
+  process.env['INPUT_GITHUB-TOKEN'] = 'abc'
+  process.env['INPUT_REMOVE-STALE-REPORTS'] = 'true'
+  process.env['INPUT_CUSTOM-HEADER'] = 'abc'
+  process.env['INPUT_CUSTOM-FOOTER'] = 'abc'
+  process.env['INPUT_PR-NUMBER'] = '42'
+
+  process.env['INPUT_TERRAFORM-TEXT'] = join(root, 'fixtures/terraform.txt')
+  process.env['INPUT_TERRAFORM-JSON'] = join(root, 'fixtures/terraform.json')
+
+  process.env.GITHUB_EVENT_PATH = join(root, 'fixtures/push.payload.json')
+
+  const { default: context } = await import('../lib/context.js')
+  const data = context()
+
+  assert.equal(data.prNumber, 42)
+})

--- a/test/context.js
+++ b/test/context.js
@@ -36,4 +36,16 @@ test('context', async assert => {
   assert.match(data.customFooter, ['abc'])
   assert.equal(data.showHeader, true)
   assert.equal(data.showFooter, true)
+  assert.equal(data.prNumber, 2)
+})
+
+test('context with explicit pr-number overrides pull_request', async assert => {
+  process.env['INPUT_PR-NUMBER'] = '99'
+
+  const { default: context } = await import('../lib/context.js')
+  const data = context()
+
+  assert.equal(data.prNumber, 99)
+
+  delete process.env['INPUT_PR-NUMBER']
 })

--- a/test/fixtures/push.payload.json
+++ b/test/fixtures/push.payload.json
@@ -1,0 +1,16 @@
+{
+  "action": "push",
+  "repository": {
+    "id": 186853002,
+    "name": "Hello-World",
+    "full_name": "Codertocat/Hello-World",
+    "owner": {
+      "login": "Codertocat",
+      "id": 21031067
+    }
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067
+  }
+}

--- a/test/stale.js
+++ b/test/stale.js
@@ -1,0 +1,89 @@
+import { test } from 'tap'
+
+const UNIQUE_IDENTIFIER = '<!-- ahmadnassri-action-terraform-report -->'
+const RUN_SIGNATURE = '<!-- owner-repo-current-sha-1234 -->'
+const OLD_SIGNATURE = '<!-- owner-repo-old-sha-5678 -->'
+
+const data = {
+  token: 'test-token',
+  prNumber: 42,
+  uniqueIdentifier: UNIQUE_IDENTIFIER,
+  runSignature: RUN_SIGNATURE
+}
+
+const mockContext = { repo: { owner: 'owner', repo: 'repo' } }
+
+function makeOctokit ({ comments = [], onDelete = () => {} } = {}) {
+  return {
+    paginate: async (_method, _params) => comments,
+    rest: {
+      issues: {
+        listComments: () => {},
+        deleteComment: async ({ comment_id }) => onDelete(comment_id)
+      }
+    }
+  }
+}
+
+test('stale - uses paginate to fetch all comments', async t => {
+  let paginateCalled = false
+
+  const octokit = {
+    paginate: async (_method, params) => {
+      paginateCalled = true
+      t.equal(params.issue_number, 42)
+      return []
+    },
+    rest: { issues: { listComments: () => {}, deleteComment: async () => {} } }
+  }
+
+  const { default: stale } = await t.mockImport('../lib/stale.js', {
+    '@actions/github': { getOctokit: () => octokit, context: mockContext },
+    '@actions/core': { warning: () => {} }
+  })
+
+  await stale(data)
+  t.ok(paginateCalled)
+})
+
+test('stale - only deletes stale comments, not current run or unrelated ones', async t => {
+  const deleted = []
+  const comments = [
+    { id: 1, body: `${UNIQUE_IDENTIFIER}\n${OLD_SIGNATURE}` },     // stale — should be deleted
+    { id: 2, body: 'unrelated comment' },                            // not from this action
+    { id: 3, body: `${UNIQUE_IDENTIFIER}\n${RUN_SIGNATURE}` }       // current run — should NOT be deleted
+  ]
+
+  const { default: stale } = await t.mockImport('../lib/stale.js', {
+    '@actions/github': { getOctokit: () => makeOctokit({ comments, onDelete: id => deleted.push(id) }), context: mockContext },
+    '@actions/core': { warning: () => {} }
+  })
+
+  await stale(data)
+  t.same(deleted, [1])
+})
+
+test('stale - warning includes error message when delete fails', async t => {
+  const warnings = []
+  const comments = [{ id: 99, body: `${UNIQUE_IDENTIFIER}\n${OLD_SIGNATURE}` }]
+
+  const octokit = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        listComments: () => {},
+        deleteComment: async () => { throw new Error('Forbidden') }
+      }
+    }
+  }
+
+  const { default: stale } = await t.mockImport('../lib/stale.js', {
+    '@actions/github': { getOctokit: () => octokit, context: mockContext },
+    '@actions/core': { warning: msg => warnings.push(msg) }
+  })
+
+  await stale(data)
+  t.equal(warnings.length, 1)
+  t.match(warnings[0], '99')
+  t.match(warnings[0], 'Forbidden')
+})


### PR DESCRIPTION
 # Description
- Add a pr-number input that allows the action to be triggered from non-pull-request events (e.g. push, workflow_dispatch). When provided, it overrides the PR number derived from the event payload; when absent on a non-PR event, the action exits with an error instead of silently doing nothing.
- Fix stale comment deletion: stale.js was reading issue_number directly from the GitHub context payload, which is unavailable outside PR events. It now receives prNumber from the caller alongside the rest of the data.
- Switch stale comment fetching to octokit.paginate so all comments are retrieved when there are more than 30 comments per page.
 
# Test plan
- [x] context.js: existing test updated to assert prNumber equals the PR number from the event payload; new test asserts INPUT_PR-NUMBER=99 overrides the event payload
  value.
- [x] context-pr-number.js: new test verifies that a push event with INPUT_PR-NUMBER=42 resolves to prNumber: 42.
- [x] stale.js: new test suite covering: paginate is called with the correct issue_number; only stale comments (not the current run or unrelated comments) are deleted; delete failures emit a warning with the comment ID and error message.



